### PR TITLE
[DATA] Fix map of Taiwan

### DIFF
--- a/data/geography.json
+++ b/data/geography.json
@@ -5321,7 +5321,8 @@
             ],
             "x_opencti_aliases": [
                 "TWA",
-                "TW"
+                "TW",
+                "TWN"
             ],
             "x_opencti_location_type": "Country"
         },


### PR DESCRIPTION
We have update the opencti dataset used by the connector, it misses the aliases TWN to be able to work

Related issues:

[#4955](https://github.com/OpenCTI-Platform/opencti/issues/4955)