### PR TITLE
chore: audit & align issue templates (#31)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ pycti.egg-info
 logs
 test.py
 .idea
+
+# Keep the GitHub issue template chooser config (the bare config.yml rule above would otherwise ignore it)
+!.github/ISSUE_TEMPLATE/config.yml


### PR DESCRIPTION
Closes #31

Audits and aligns the GitHub issue templates with the canonical Filigran standard.

## Changes
- Added the missing `config.yml` set to the public standard (`blank_issues_enabled: true` only).
- The repository's `.gitignore` had a bare `config.yml` rule that also matched `.github/ISSUE_TEMPLATE/config.yml` and prevented it from being committed; added an explicit negation exception so the issue-template chooser config is tracked while runtime `config.yml` files stay ignored.
- Verified `bug_report.md`, `feature_request.md` and `question.md` names, descriptions, titles, labels and types are consistent with the standard (no duplicates).
- No security `contact_link` (native private vulnerability reporting is enabled) and no Filigran community Slack link.

No documentation or pycti templates apply to this repository.